### PR TITLE
fastocr: pin to 0.3.0

### DIFF
--- a/Update.hs
+++ b/Update.hs
@@ -28,7 +28,11 @@ packageSet = do
         `fetchUrl` const
           "https://github.com/samuelngs/apple-emoji-linux/releases/download/latest/AppleColorEmoji.ttf"
   -----------------------------------------------------------------------------
-  define $ package "fastocr" `fromPypi` "fastocr"
+  define $ 
+    package "fastocr"
+      -- no idea with 'Could not find a version that satisfies the requirement PyQt5-Qt5' in version 0.3.1
+      `sourceManual` "0.3.0"
+      `fetchPypi` "fastocr"
   -----------------------------------------------------------------------------
   define $ package "feeluown-core" `fromPypi` "feeluown"
   let fuoPlugins = mapM_ $ \x -> define $ package ("feeluown-" <> x) `fromPypi` ("fuo_" <> x)


### PR DESCRIPTION
Failed to build 0.3.1 :
```
builder for '/nix/store/fbxzvr6pxkajx8x2s9v3qmzw22rizi93-fastocr-0.3.1.drv' failed with exit code 1; last 10 log lines:
  adding 'fastocr-0.3.1.dist-info/RECORD'
  removing build/bdist.linux-x86_64/wheel
  Finished executing setuptoolsBuildPhase
  glibPreInstallPhase
  installing
  Executing pipInstallPhase
  /build/fastocr-0.3.1/dist /build/fastocr-0.3.1
  Processing ./fastocr-0.3.1-py3-none-any.whl
  ERROR: Could not find a version that satisfies the requirement PyQt5-Qt5 (from fastocr)
  ERROR: No matching distribution found for PyQt5-Qt5
```